### PR TITLE
feat(actions): Auto Tag and Release

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,40 @@
+name: Auto Tag and Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+  pull-requests: read
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      newtag: ${{ steps.tag.outputs.new-tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: phish108/autotag-action@v1.1.64
+        id: tag
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN}}
+          with-v: "true"
+          branch: master
+          bump: major
+          release-branch: master
+          dry-run: "true"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: tag
+    steps:
+      - uses: actions/checkout@v3
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "v${{needs.tag.outputs.newtag}}"
+          prerelease: false


### PR DESCRIPTION
È stata aggiunta un'Action che genera in automatico la Release quando un push nel master viene effettuato.
L'action è in grado di gestire in automatico la versione della release e la incrementa in automatico di 1 (v1.0.0 --> v2.0.0). 
L'incremento può essere specificato nel testo del commit inserendo uno di questi tag alla fine:
- `#major`: +1.0.0 (v1.0.0 --> v2.0.0)
- `#minor`: +0.1.0 (v1.0.0 --> v1.1.0)
- `#patch`: +0.0.1 (v1.0.0 --> v1.0.1)