### PR TITLE
fix(actions): Generazione changelog

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -32,17 +32,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate changelog
-        uses: orhun/git-cliff-action@v2
-        id: git-cliff
-        with:
-          config: .github/workflows/configs/conf.toml
-          args: -vv --latest --unreleased --strip header --tag v${{needs.tag.outputs.newtag}}
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Install git-cliff 🏔
+        run: |
+          export version=1.2.0
+          wget "https://github.com/orhun/git-cliff/releases/download/v${version}/git-cliff-${version}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xvzf git-cliff-*.tar.gz
+          cp "git-cliff-${version}/git-cliff" /usr/local/bin/
+
+      - name: Generate a changelog
+        run: git-cliff -vv --latest --unreleased --strip header --config .github/workflows/conf.toml --tag v${{needs.tag.outputs.newtag}} -o log.md
         env:
-          OUTPUT: CHANGES.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cat Changelog
-        run: cat ${{ steps.git-cliff.outputs.changelog }}
+        run: cat log.md
 
       - name: Create Release
         uses: actions/create-release@v1
@@ -51,5 +57,5 @@ jobs:
         with:
           tag_name: "v${{needs.tag.outputs.newtag}}"
           release_name: "v${{needs.tag.outputs.newtag}}"
-          body: ${{ steps.git-cliff.outputs.content }}
+          body_path: log.md
  

--- a/.github/workflows/configs/conf.toml
+++ b/.github/workflows/configs/conf.toml
@@ -13,7 +13,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | upper_first }}
     {% for commit in commits %}
-        - {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ github_repo_link }}/commit/{{ commit.id }})) by {{ commit.author.name }}\
+        - {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}]({{ github_repo_link }}/commit/{{ commit.id }})) \
     {% endfor %}
 {% endfor %}\n
 
@@ -40,9 +40,10 @@ filter_unconventional = false
 split_commits = false
 # regex for parsing and grouping commits
 
-# commit_preprocessors = [
-#     {pattern = "username", replace_command="gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/ncvescera/provaactions/commits/$COMMIT_SHA | jq -r .author.login"},
-# ]
+commit_preprocessors = [
+    {pattern = ".*", replace_command="echo -n \"$(head -1 $@) @$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/ncvescera/provaactions/commits/$COMMIT_SHA | jq -r .author.login)\""}
+]
+
 commit_parsers = [
     { message = "^feat", group = "Features 🚀"},
     { message = "^fix", group = "Fixes 🔨"},

--- a/.github/workflows/configs/conf.toml
+++ b/.github/workflows/configs/conf.toml
@@ -41,7 +41,7 @@ split_commits = false
 # regex for parsing and grouping commits
 
 commit_preprocessors = [
-    {pattern = ".*", replace_command="echo -n \"$(head -1 $@) @$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/ncvescera/provaactions/commits/$COMMIT_SHA | jq -r .author.login)\""}
+    {pattern = ".*", replace_command="echo -n \"$(head -1 $@) @$(gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' /repos/Typing-Monkeys/AppuntiUniversita/commits/$COMMIT_SHA | jq -r .author.login)\""}
 ]
 
 commit_parsers = [


### PR DESCRIPTION
Risolti alcuni problemi dell'action che effettua la Release in automatico.

- Migliorato il file di configurazione per la generazione dei changelog per le Release: ora viene aggiunto il tag all'autore del commit. In questo modo nella release viene creata (in automatico) la sezione 'Contributors'.
-  Sistemato un problema per il quale veniva mostrato tutto il corpo dei commit nella sezione 'Commits'. Questo era dovuto al fatto che i commit non 'conventional' non hanno la distnzione tra corpo e header del commit. Ora viene mostrata solo la prima riga dei commit non convenzionali.

![image](https://github.com/Typing-Monkeys/AppuntiUniversita/assets/10250769/9ccf6354-18f3-4221-a2ad-7f2208a8b298)
_Esempio di release_