### PR TITLE
chore: Aggiunto .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
Aggiunto .gitattributes file per impedire il riconoscimento dei Notebook Jupyter e mostrarli come il principale linguaggio utilizzato per questa repo.

Così facendo dovremmo avere LaTex come linguaggio principale e poi i notebook vengono contati come file e non più il suo contenuto.